### PR TITLE
Add Linux loudminer.sh with background XMRig execution and huge pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,45 @@
 # Batch-XMR
 
-This repository contains a Windows batch script that automates downloading and running the [XMRig](https://github.com/xmrig/xmrig) miner. The script was written to quickly set up mining on systems where administrative privileges are unavailable.
+This repository now includes a Linux shell script that automates downloading and running the [XMRig](https://github.com/xmrig/xmrig) miner in the background.
 
 ## Features
 
-- Downloads the specified XMRig release using PowerShell or `certutil` as a fallback.
-- Validates the download with a SHA256 checksum.
-- Logs activity to `%LOCALAPPDATA%\xmrig\xmrig_setup.log`.
-- Allows the wallet, pool and XMRig version to be supplied as command‑line arguments.
-- Retries downloads and extraction if they fail.
-- Cleans up the temporary ZIP file after extraction.
+- One-command setup for Linux using `bash`.
+- Downloads a chosen XMRig release from GitHub.
+- Optional SHA256 verification for the default version.
+- Starts mining in the background with `nohup`.
+- Enables huge pages flags (`--huge-pages` and `--randomx-1gb-pages`).
+- Writes setup/runtime logs and stores a PID file for easy stop/restart.
 
-## Usage
+## Usage (Linux)
 
-1. Copy `loudminer.bat` to the Windows machine.
-2. From a command prompt, run:
-   ```
-   loudminer.bat [WALLET] [POOL] [VERSION]
-   ```
-   - `WALLET` – your Monero wallet address.
-   - `POOL` – mining pool in the form `host:port`.
-   - `VERSION` – XMRig release version (default: `6.22.2`).
-3. The miner will be extracted to `%LOCALAPPDATA%\xmrig` and started in the background.
+```bash
+chmod +x loudminer.sh
+./loudminer.sh [WALLET] [POOL] [VERSION]
+```
 
-> **Note**: Only run the miner on systems where you have permission to do so.
+Defaults:
+- `WALLET`: `45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL`
+- `POOL`: `pool.hashvault.pro:443`
+- `VERSION`: `6.22.2`
+
+### Paths used
+
+- Install dir: `~/.local/share/xmrig`
+- Setup log: `~/.local/share/xmrig/xmrig_setup.log`
+- Runtime log: `~/.local/share/xmrig/xmrig_run.log`
+- PID file: `~/.local/share/xmrig/xmrig.pid`
+
+### Stop miner
+
+```bash
+kill $(cat ~/.local/share/xmrig/xmrig.pid)
+```
 
 ## Files
 
-- `loudminer.bat` – batch script that handles download, verification and execution of XMRig.
-- `README.md` – documentation for this repository.
+- `loudminer.sh` – Linux shell script for download, verification and background execution.
+- `loudminer.bat` – original Windows batch version.
+- `README.md` – documentation.
 
-## Disclaimer
-
-This project is provided for educational purposes. Use it at your own risk and ensure it complies with local laws and the policies of the system on which it is executed.
+> Only run miners on systems where you have explicit permission.

--- a/loudminer.sh
+++ b/loudminer.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# XMRig Linux setup and background runner
+# Usage: ./loudminer.sh [WALLET] [POOL] [VERSION]
+
+WALLET="${1:-45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL}"
+POOL="${2:-pool.hashvault.pro:443}"
+XMRIG_VERSION="${3:-6.22.2}"
+
+TARGET_DIR="${HOME}/.local/share/xmrig"
+LOG_FILE="${TARGET_DIR}/xmrig_setup.log"
+RUN_LOG="${TARGET_DIR}/xmrig_run.log"
+PID_FILE="${TARGET_DIR}/xmrig.pid"
+
+mkdir -p "$TARGET_DIR"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    log "Missing required command: $1"
+    exit 1
+  }
+}
+
+require_cmd curl
+require_cmd tar
+require_cmd sha256sum
+
+ARCHIVE="xmrig-${XMRIG_VERSION}-linux-static-x64.tar.gz"
+URL="https://github.com/xmrig/xmrig/releases/download/v${XMRIG_VERSION}/${ARCHIVE}"
+ARCHIVE_PATH="${TARGET_DIR}/${ARCHIVE}"
+
+# Pinned checksum for default version only.
+EXPECTED_CHECKSUM=""
+if [[ "$XMRIG_VERSION" == "6.22.2" ]]; then
+  EXPECTED_CHECKSUM="4fd863531ce110d6c61881077dca879953bf6f0f7896b2f1269fc6c2af8fda4e"
+fi
+
+log "Downloading ${URL}"
+curl -fL --retry 4 --retry-delay 3 -o "$ARCHIVE_PATH" "$URL"
+
+if [[ -n "$EXPECTED_CHECKSUM" ]]; then
+  log "Verifying checksum for ${ARCHIVE}"
+  GOT_CHECKSUM="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+  if [[ "$GOT_CHECKSUM" != "$EXPECTED_CHECKSUM" ]]; then
+    log "Checksum mismatch! expected=${EXPECTED_CHECKSUM} got=${GOT_CHECKSUM}"
+    exit 1
+  fi
+fi
+
+log "Extracting ${ARCHIVE}"
+tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
+rm -f "$ARCHIVE_PATH"
+
+MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name 'xmrig-*' | head -n 1)"
+if [[ -z "$MINER_DIR" || ! -x "$MINER_DIR/xmrig" ]]; then
+  log "xmrig binary not found after extraction"
+  exit 1
+fi
+
+if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" >/dev/null 2>&1; then
+  log "xmrig is already running with PID $(cat "$PID_FILE")"
+  exit 0
+fi
+
+log "Starting xmrig in background (logs: ${RUN_LOG})"
+nohup "$MINER_DIR/xmrig" \
+  -o "$POOL" \
+  -u "$WALLET" \
+  -p x \
+  --tls \
+  --donate-level=0 \
+  --huge-pages \
+  --randomx-1gb-pages \
+  >> "$RUN_LOG" 2>&1 &
+
+echo $! > "$PID_FILE"
+log "xmrig started with PID $(cat "$PID_FILE")"
+log "Done. Stop with: kill \$(cat '$PID_FILE')"


### PR DESCRIPTION
### Motivation
- Provide a Linux-friendly installer/runner for XMRig so the miner can be installed and started on Linux systems with minimal steps. 
- Use the supplied wallet as the default and enable RandomX huge-page options for improved performance. 

### Description
- Add `loudminer.sh`, a Bash script that downloads a chosen XMRig release from GitHub, optionally verifies a pinned SHA256 for the default version, extracts it to `~/.local/share/xmrig`, and removes the archive. 
- Start the miner in the background using `nohup`, record the process ID in a PID file at `~/.local/share/xmrig/xmrig.pid`, and write setup/runtime messages to `xmrig_setup.log` and `xmrig_run.log`. 
- Enable huge-page runtime flags with `--huge-pages` and `--randomx-1gb-pages`, and require `curl`, `tar`, and `sha256sum` to be present. 
- Update `README.md` with Linux usage instructions, default `WALLET`/`POOL`/`VERSION` values, paths used, and the stop command. 

### Testing
- Run a syntax-only check with `bash -n loudminer.sh`, which completed successfully. 
- Verify repository changes with `git status --short`, which showed the expected additions (`loudminer.sh` and updated `README.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc80e31308325a6165931fddf6160)