### PR TITLE
Fix Linux miner background startup reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository now includes a Linux shell script that automates downloading and
 - One-command setup for Linux using `bash`.
 - Downloads a chosen XMRig release from GitHub.
 - Optional SHA256 verification for the default version.
-- Starts mining in the background with `nohup`.
+- Starts mining in true daemon mode using XMRig `--background`.
 - Enables huge pages flags (`--huge-pages` and `--randomx-1gb-pages`).
 - Writes setup/runtime logs and stores a PID file for easy stop/restart.
 

--- a/loudminer.sh
+++ b/loudminer.sh
@@ -56,7 +56,11 @@ log "Extracting ${ARCHIVE}"
 tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
 rm -f "$ARCHIVE_PATH"
 
-MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name 'xmrig-*' | head -n 1)"
+MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name "xmrig-${XMRIG_VERSION}*" | head -n 1)"
+if [[ -z "$MINER_DIR" ]]; then
+  MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name 'xmrig-*' | head -n 1)"
+fi
+
 if [[ -z "$MINER_DIR" || ! -x "$MINER_DIR/xmrig" ]]; then
   log "xmrig binary not found after extraction"
   exit 1
@@ -68,16 +72,24 @@ if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" >/dev/null 2>&1; then
 fi
 
 log "Starting xmrig in background (logs: ${RUN_LOG})"
-nohup "$MINER_DIR/xmrig" \
+"$MINER_DIR/xmrig" \
+  --background \
+  --log-file "$RUN_LOG" \
   -o "$POOL" \
   -u "$WALLET" \
   -p x \
   --tls \
   --donate-level=0 \
   --huge-pages \
-  --randomx-1gb-pages \
-  >> "$RUN_LOG" 2>&1 &
+  --randomx-1gb-pages
 
-echo $! > "$PID_FILE"
+sleep 1
+XMRIG_PID="$(pgrep -n -f "$MINER_DIR/xmrig" || true)"
+if [[ -z "$XMRIG_PID" ]] || ! kill -0 "$XMRIG_PID" >/dev/null 2>&1; then
+  log "xmrig failed to stay running in the background. Check ${RUN_LOG}"
+  exit 1
+fi
+
+echo "$XMRIG_PID" > "$PID_FILE"
 log "xmrig started with PID $(cat "$PID_FILE")"
 log "Done. Stop with: kill \$(cat '$PID_FILE')"


### PR DESCRIPTION
### Motivation

- Ensure the XMRig miner actually detaches and runs as a true background daemon instead of relying on an ad-hoc `nohup` invocation. 
- Provide deterministic PID handling so the script can reliably detect/stop an already-running miner. 
- Reduce mis-launches from stale extractions by preferring the requested version directory when selecting the extracted miner folder.

### Description

- Replace the `nohup ... &` launch with XMRig's native daemon mode using `--background` and `--log-file` to let the binary perform proper detachment. 
- Add a post-start health check that sleeps briefly, locates the daemon PID via `pgrep`, validates the process is alive, and fails with a log hint if background startup did not stick. 
- Change PID file population to use the detected daemon PID instead of the shell background job PID. 
- Improve extraction folder selection to prefer `xmrig-${XMRIG_VERSION}*` and fall back to any `xmrig-*` folder, and update `README.md` to reflect daemon-mode startup.

### Testing

- Shell syntax check `bash -n loudminer.sh` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcca6dc10832585ff06cbc0a0f0e6)