### PR TITLE
Validate XMRig release checksums and support resolving `latest` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This repository now includes a Linux shell script that automates downloading and
 
 ```bash
 chmod +x loudminer.sh
-./loudminer.sh [WALLET] [POOL] [VERSION]
+./loudminer.sh [WALLET] [POOL] [VERSION|latest]
 ```
 
 Defaults:
 - `WALLET`: `45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL`
 - `POOL`: `pool.hashvault.pro:443`
-- `VERSION`: `6.22.2`
+- `VERSION`: `latest` (auto-resolved from GitHub), or pin any specific version like `6.22.2`
 
 ### Paths used
 

--- a/loudminer.bat
+++ b/loudminer.bat
@@ -18,7 +18,7 @@ REM ----- Configuration Variables -----
 REM Default values can be overridden via command-line arguments:
 REM   %1 - WALLET address
 REM   %2 - POOL URL (e.g., pool.hashvault.pro:443)
-REM   %3 - XMRig version
+REM   %3 - XMRig version (or latest)
 
 if not "%~1"=="" set "WALLET=%~1"
 if not defined WALLET set "WALLET=4BKmqkuobnj6MNsW78CLzS6ivQjZWqXppf6bbJsp4xW2KfvasaeEw2FL1A5HnGENyN2eardtcrWtg7JFrCMNDbmtM4vePEm"
@@ -27,13 +27,23 @@ if not "%~2"=="" set "POOL=%~2"
 if not defined POOL set "POOL=pool.hashvault.pro:443"
 
 if not "%~3"=="" set "XMRIG_VERSION=%~3"
-if not defined XMRIG_VERSION set "XMRIG_VERSION=6.22.2"
+if not defined XMRIG_VERSION set "XMRIG_VERSION=latest"
+
+if /i "%XMRIG_VERSION%"=="latest" (
+    echo [*] Resolving latest XMRig release version from GitHub API...
+    for /f "usebackq delims=" %%i in (`powershell -Command "(Invoke-RestMethod -UseBasicParsing 'https://api.github.com/repos/xmrig/xmrig/releases/latest').tag_name.TrimStart('v')"`) do set "XMRIG_VERSION=%%i"
+    if not defined XMRIG_VERSION (
+        echo [!] Failed to resolve latest XMRig version.
+        pause
+        exit /b 1
+    )
+    echo [*] Using latest XMRig version: %XMRIG_VERSION%
+)
 
 set "ZIP_FILE=xmrig-%XMRIG_VERSION%-msvc-win64.zip"
 set "DOWNLOAD_URL=https://github.com/xmrig/xmrig/releases/download/v%XMRIG_VERSION%/%ZIP_FILE%"
 
-REM Expected SHA256 Checksum for version 6.22.2
-set "EXPECTED_CHECKSUM=1d903d39c7e4e1706c32c44721d6a6c851aa8c4c10df1479478ee93cd67301bc"
+set "CHECKSUMS_FILE=SHA256SUMS-%XMRIG_VERSION%.txt"
 
 REM ----- Determine Target Directory and Logging -----
 set "TARGET_DIR=%LOCALAPPDATA%\xmrig"
@@ -102,7 +112,25 @@ echo [√] Download successful.
 echo [%date% %time%] Download successful. >> "%LOG_FILE%"
 
 REM ----- Verify Download with Checksum Validation -----
+echo [*] Downloading SHA256SUMS...
+powershell -Command "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; Try { (New-Object Net.WebClient).DownloadFile('https://github.com/xmrig/xmrig/releases/download/v%XMRIG_VERSION%/SHA256SUMS', '%TARGET_DIR%\%CHECKSUMS_FILE%') } Catch { exit 1 }" >> "%LOG_FILE%" 2>&1
+if not exist "%TARGET_DIR%\%CHECKSUMS_FILE%" (
+    echo [!] Failed to download SHA256SUMS.
+    echo [%date% %time%] Failed to download SHA256SUMS. >> "%LOG_FILE%"
+    pause
+    exit /b 1
+)
+
 echo [*] Verifying checksum...
+for /f "usebackq tokens=1,2" %%a in ("%TARGET_DIR%\%CHECKSUMS_FILE%") do (
+    if /i "%%b"=="%ZIP_FILE%" set "EXPECTED_CHECKSUM=%%a"
+)
+if not defined EXPECTED_CHECKSUM (
+    echo [!] Could not find checksum entry for %ZIP_FILE%.
+    echo [%date% %time%] Missing checksum entry for %ZIP_FILE%. >> "%LOG_FILE%"
+    pause
+    exit /b 1
+)
 for /f "usebackq tokens=*" %%i in (`powershell -Command "Get-FileHash -Algorithm SHA256 '%TARGET_DIR%\%ZIP_FILE%' | ForEach-Object { $_.Hash }"`) do set "FILE_CHECKSUM=%%i"
 echo [*] Expected: %EXPECTED_CHECKSUM%
 echo [*] Got: %FILE_CHECKSUM%
@@ -145,6 +173,7 @@ echo [%date% %time%] Extraction successful to: "%MINER_DIR%" >> "%LOG_FILE%"
 
 REM ----- Cleanup: Remove Downloaded ZIP File -----
 del "%TARGET_DIR%\%ZIP_FILE%" >nul 2>&1
+del "%TARGET_DIR%\%CHECKSUMS_FILE%" >nul 2>&1
 echo [*] Cleaned up ZIP file.
 echo [%date% %time%] Cleaned up ZIP file. >> "%LOG_FILE%"
 

--- a/loudminer.sh
+++ b/loudminer.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # XMRig Linux setup and background runner
-# Usage: ./loudminer.sh [WALLET] [POOL] [VERSION]
+# Usage: ./loudminer.sh [WALLET] [POOL] [VERSION|latest]
 
 WALLET="${1:-45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL}"
 POOL="${2:-pool.hashvault.pro:443}"
-XMRIG_VERSION="${3:-6.22.2}"
+XMRIG_VERSION="${3:-latest}"
 
 TARGET_DIR="${HOME}/.local/share/xmrig"
 LOG_FILE="${TARGET_DIR}/xmrig_setup.log"
@@ -29,32 +29,50 @@ require_cmd() {
 require_cmd curl
 require_cmd tar
 require_cmd sha256sum
+require_cmd awk
+
+if [[ "$XMRIG_VERSION" == "latest" ]]; then
+  log "Resolving latest XMRig release version from GitHub API"
+  XMRIG_VERSION="$(
+    curl -fsSL "https://api.github.com/repos/xmrig/xmrig/releases/latest" \
+      | awk -F'"' '/"tag_name":/ {gsub(/^v/, "", $4); print $4; exit}'
+  )"
+  if [[ -z "$XMRIG_VERSION" ]]; then
+    log "Failed to resolve latest XMRig version"
+    exit 1
+  fi
+  log "Using latest XMRig version: ${XMRIG_VERSION}"
+fi
 
 ARCHIVE="xmrig-${XMRIG_VERSION}-linux-static-x64.tar.gz"
 URL="https://github.com/xmrig/xmrig/releases/download/v${XMRIG_VERSION}/${ARCHIVE}"
 ARCHIVE_PATH="${TARGET_DIR}/${ARCHIVE}"
 
-# Pinned checksum for default version only.
-EXPECTED_CHECKSUM=""
-if [[ "$XMRIG_VERSION" == "6.22.2" ]]; then
-  EXPECTED_CHECKSUM="4fd863531ce110d6c61881077dca879953bf6f0f7896b2f1269fc6c2af8fda4e"
-fi
+CHECKSUMS_URL="https://github.com/xmrig/xmrig/releases/download/v${XMRIG_VERSION}/SHA256SUMS"
+CHECKSUMS_PATH="${TARGET_DIR}/SHA256SUMS-${XMRIG_VERSION}.txt"
 
 log "Downloading ${URL}"
 curl -fL --retry 4 --retry-delay 3 -o "$ARCHIVE_PATH" "$URL"
 
-if [[ -n "$EXPECTED_CHECKSUM" ]]; then
-  log "Verifying checksum for ${ARCHIVE}"
-  GOT_CHECKSUM="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
-  if [[ "$GOT_CHECKSUM" != "$EXPECTED_CHECKSUM" ]]; then
-    log "Checksum mismatch! expected=${EXPECTED_CHECKSUM} got=${GOT_CHECKSUM}"
-    exit 1
-  fi
+log "Fetching upstream checksums from ${CHECKSUMS_URL}"
+curl -fL --retry 4 --retry-delay 3 -o "$CHECKSUMS_PATH" "$CHECKSUMS_URL"
+
+log "Verifying checksum for ${ARCHIVE}"
+EXPECTED_CHECKSUM="$(awk -v f="$ARCHIVE" '$2==f {print $1}' "$CHECKSUMS_PATH")"
+GOT_CHECKSUM="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+if [[ -z "$EXPECTED_CHECKSUM" ]]; then
+  log "Could not find checksum entry for ${ARCHIVE} in ${CHECKSUMS_PATH}"
+  exit 1
+fi
+if [[ "$GOT_CHECKSUM" != "$EXPECTED_CHECKSUM" ]]; then
+  log "Checksum mismatch! expected=${EXPECTED_CHECKSUM} got=${GOT_CHECKSUM}"
+  exit 1
 fi
 
 log "Extracting ${ARCHIVE}"
 tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
 rm -f "$ARCHIVE_PATH"
+rm -f "$CHECKSUMS_PATH"
 
 MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name "xmrig-${XMRIG_VERSION}*" | head -n 1)"
 if [[ -z "$MINER_DIR" ]]; then


### PR DESCRIPTION
### Motivation
- Users experienced checksum mismatches because the scripts relied on a single hardcoded checksum for an old XMRig release. 
- The intent is to allow using the newest XMRig build by default while verifying downloads against the official per-release checksums. 

### Description
- Change default `VERSION` to `latest` and auto-resolve the newest release tag from the GitHub Releases API in `loudminer.sh` and `loudminer.bat`. 
- Download the release `SHA256SUMS` file for the selected version and validate the downloaded archive against the checksum entry for that archive before extraction. 
- Remove stale hardcoded checksums and add error handling for missing checksum entries, checksum mismatches, and failed version resolution. 
- Add `awk` requirement on Linux, clean up temporary `SHA256SUMS` files after verification, and update `README.md` usage to show `[VERSION|latest]`. 

### Testing
- Ran `bash -n loudminer.sh` to check script syntax and it succeeded. 
- Verified the change set via a diff review to confirm `loudminer.sh`, `loudminer.bat`, and `README.md` updates applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bce26afd48325b68753483725dc8e)