### PR TITLE
Pin loudminer to XMRig v6.26.0 and remove checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This repository now includes a Linux shell script that automates downloading and
 ## Features
 
 - One-command setup for Linux using `bash`.
-- Downloads a chosen XMRig release from GitHub.
-- Optional SHA256 verification for the default version.
+- Downloads XMRig v6.26.0 static Linux build from GitHub.
 - Starts mining in true daemon mode using XMRig `--background`.
 - Enables huge pages flags (`--huge-pages` and `--randomx-1gb-pages`).
 - Writes setup/runtime logs and stores a PID file for easy stop/restart.
@@ -15,13 +14,13 @@ This repository now includes a Linux shell script that automates downloading and
 
 ```bash
 chmod +x loudminer.sh
-./loudminer.sh [WALLET] [POOL] [VERSION|latest]
+./loudminer.sh [WALLET] [POOL]
 ```
 
 Defaults:
 - `WALLET`: `45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL`
 - `POOL`: `pool.hashvault.pro:443`
-- `VERSION`: `latest` (auto-resolved from GitHub), or pin any specific version like `6.22.2`
+- XMRig build is pinned to: `v6.26.0` (`xmrig-6.26.0-linux-static-x64.tar.gz`)
 
 ### Paths used
 
@@ -38,7 +37,7 @@ kill $(cat ~/.local/share/xmrig/xmrig.pid)
 
 ## Files
 
-- `loudminer.sh` – Linux shell script for download, verification and background execution.
+- `loudminer.sh` – Linux shell script for download and background execution.
 - `loudminer.bat` – original Windows batch version.
 - `README.md` – documentation.
 

--- a/loudminer.sh
+++ b/loudminer.sh
@@ -2,16 +2,19 @@
 set -euo pipefail
 
 # XMRig Linux setup and background runner
-# Usage: ./loudminer.sh [WALLET] [POOL] [VERSION|latest]
+# Usage: ./loudminer.sh [WALLET] [POOL]
 
 WALLET="${1:-45nvZgTEtE4j5WGwP6EuKWXM7KTYuNnc5hTYyPW7MQ9AX2SHLs3SeSAJNrrtUW4FLvMobFGcboXaLY4xtE1pnAmU63pTjwL}"
 POOL="${2:-pool.hashvault.pro:443}"
-XMRIG_VERSION="${3:-latest}"
 
 TARGET_DIR="${HOME}/.local/share/xmrig"
 LOG_FILE="${TARGET_DIR}/xmrig_setup.log"
 RUN_LOG="${TARGET_DIR}/xmrig_run.log"
 PID_FILE="${TARGET_DIR}/xmrig.pid"
+
+XMRIG_URL="https://github.com/xmrig/xmrig/releases/download/v6.26.0/xmrig-6.26.0-linux-static-x64.tar.gz"
+ARCHIVE="${XMRIG_URL##*/}"
+ARCHIVE_PATH="${TARGET_DIR}/${ARCHIVE}"
 
 mkdir -p "$TARGET_DIR"
 
@@ -28,53 +31,15 @@ require_cmd() {
 
 require_cmd curl
 require_cmd tar
-require_cmd sha256sum
-require_cmd awk
 
-if [[ "$XMRIG_VERSION" == "latest" ]]; then
-  log "Resolving latest XMRig release version from GitHub API"
-  XMRIG_VERSION="$(
-    curl -fsSL "https://api.github.com/repos/xmrig/xmrig/releases/latest" \
-      | awk -F'"' '/"tag_name":/ {gsub(/^v/, "", $4); print $4; exit}'
-  )"
-  if [[ -z "$XMRIG_VERSION" ]]; then
-    log "Failed to resolve latest XMRig version"
-    exit 1
-  fi
-  log "Using latest XMRig version: ${XMRIG_VERSION}"
-fi
-
-ARCHIVE="xmrig-${XMRIG_VERSION}-linux-static-x64.tar.gz"
-URL="https://github.com/xmrig/xmrig/releases/download/v${XMRIG_VERSION}/${ARCHIVE}"
-ARCHIVE_PATH="${TARGET_DIR}/${ARCHIVE}"
-
-CHECKSUMS_URL="https://github.com/xmrig/xmrig/releases/download/v${XMRIG_VERSION}/SHA256SUMS"
-CHECKSUMS_PATH="${TARGET_DIR}/SHA256SUMS-${XMRIG_VERSION}.txt"
-
-log "Downloading ${URL}"
-curl -fL --retry 4 --retry-delay 3 -o "$ARCHIVE_PATH" "$URL"
-
-log "Fetching upstream checksums from ${CHECKSUMS_URL}"
-curl -fL --retry 4 --retry-delay 3 -o "$CHECKSUMS_PATH" "$CHECKSUMS_URL"
-
-log "Verifying checksum for ${ARCHIVE}"
-EXPECTED_CHECKSUM="$(awk -v f="$ARCHIVE" '$2==f {print $1}' "$CHECKSUMS_PATH")"
-GOT_CHECKSUM="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
-if [[ -z "$EXPECTED_CHECKSUM" ]]; then
-  log "Could not find checksum entry for ${ARCHIVE} in ${CHECKSUMS_PATH}"
-  exit 1
-fi
-if [[ "$GOT_CHECKSUM" != "$EXPECTED_CHECKSUM" ]]; then
-  log "Checksum mismatch! expected=${EXPECTED_CHECKSUM} got=${GOT_CHECKSUM}"
-  exit 1
-fi
+log "Downloading ${XMRIG_URL}"
+curl -fL --retry 4 --retry-delay 3 -o "$ARCHIVE_PATH" "$XMRIG_URL"
 
 log "Extracting ${ARCHIVE}"
 tar -xzf "$ARCHIVE_PATH" -C "$TARGET_DIR"
 rm -f "$ARCHIVE_PATH"
-rm -f "$CHECKSUMS_PATH"
 
-MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name "xmrig-${XMRIG_VERSION}*" | head -n 1)"
+MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name 'xmrig-6.26.0*' | head -n 1)"
 if [[ -z "$MINER_DIR" ]]; then
   MINER_DIR="$(find "$TARGET_DIR" -maxdepth 1 -type d -name 'xmrig-*' | head -n 1)"
 fi


### PR DESCRIPTION
### Motivation

- Simplify the installer by removing upstream checksum fetching and verification to avoid depending on `SHA256SUMS` parsing and `sha256sum` tooling. 
- Pin the download to a known static XMRig build so the script reliably fetches a specific archive without resolving `latest` via the GitHub API. 
- Reduce external dependencies and runtime complexity by removing dynamic version resolution and related tooling. 

### Description

- Replaced dynamic version resolution and `SHA256SUMS` verification with a fixed `XMRIG_URL` set to `https://github.com/xmrig/xmrig/releases/download/v6.26.0/xmrig-6.26.0-linux-static-x64.tar.gz`. 
- Removed checksum-related variables, `sha256sum` and `awk` requirements, and all checksum download/validation logic from `loudminer.sh`. 
- Simplified script usage from `./loudminer.sh [WALLET] [POOL] [VERSION|latest]` to `./loudminer.sh [WALLET] [POOL]` and adjusted miner discovery to prefer `xmrig-6.26.0*` before falling back to any `xmrig-*`. 
- Updated `README.md` to reflect the pinned XMRig build and removed references to optional SHA256 verification and `latest` resolution. 

### Testing

- Verified script syntax with `bash -n loudminer.sh`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd05e77308325b1de1b21a27dc8e7)