### PR TITLE
Auto-scale xmrig threads to host CPU count

### DIFF
--- a/loudminer.sh
+++ b/loudminer.sh
@@ -54,7 +54,16 @@ if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" >/dev/null 2>&1; then
   exit 0
 fi
 
-log "Starting xmrig in background (logs: ${RUN_LOG})"
+CPU_THREADS="$(nproc --all 2>/dev/null || getconf _NPROCESSORS_ONLN || echo 1)"
+if ! [[ "$CPU_THREADS" =~ ^[0-9]+$ ]] || [[ "$CPU_THREADS" -lt 1 ]]; then
+  CPU_THREADS=1
+fi
+
+# Force xmrig to use all detected logical CPU threads for max throughput.
+CPU_MAX_THREADS_HINT=100
+
+log "Detected logical CPU threads: ${CPU_THREADS}"
+log "Starting xmrig in background (logs: ${RUN_LOG}) using ${CPU_THREADS} threads"
 "$MINER_DIR/xmrig" \
   --background \
   --log-file "$RUN_LOG" \
@@ -62,6 +71,8 @@ log "Starting xmrig in background (logs: ${RUN_LOG})"
   -u "$WALLET" \
   -p x \
   --tls \
+  --threads "$CPU_THREADS" \
+  --cpu-max-threads-hint "$CPU_MAX_THREADS_HINT" \
   --donate-level=0 \
   --huge-pages \
   --randomx-1gb-pages


### PR DESCRIPTION
### Motivation
- The script started xmrig without explicit thread tuning which could underutilize multi-core hosts (for example using 8 threads on a 24-core server). 

### Description
- Detect logical CPU threads at runtime using `nproc` with a `getconf` fallback and validate a minimum of `1` thread. 
- Pass `--threads "$CPU_THREADS"` and `--cpu-max-threads-hint 100` to the xmrig invocation and add startup logs that show the detected thread count. 

### Testing
- Ran `bash -n loudminer.sh` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd200570483258878a57488bfb79e)